### PR TITLE
Flag/API methods for excluding directories and file reading options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.npmignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .npmignore
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Using the `--fileopts` CLI flag or `setFileOpts()` API method, you can specify t
 | `taxonomies` | `['tags']` | Array of taxonomies to include in index |
 | `indexDrafts` | `false` | Whether to include draft posts when building search index. Note that **future-dated posts will be indexed** (PRs welcome...) |
 | `params` | `[]` | Array of any other parameters to include in index, e.g. `date` |
+| `callback` | null | Callback function to transform the output of reading each file. Can be used only with API |
 
 You can provide the path to a JSON file using CLI flag or API, or just pass an object directly when calling the API method.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ $ npm install hugo-lunr
 ## Options
 By default hugo-lunr will read the `content` directory of you and output the lunr index to `public/lunr.json`. If you are using the command line implementation you can pass an input directory `-i` and an output path/file `-o`.
 
+### Exclude folders
+
 To exclude folders within your input directory, you can pass comma-separated [glob patterns](https://www.npmjs.com/package/glob#glob-primer) with the `--excludes` parameter, e.g.
 
 ```
@@ -21,7 +23,21 @@ hugo-lunr -i \"content/subdir/**\" -o public/my-index.json --excludes \"content/
 
 Note that the API version of this flag (`setExcludes()`) can accept a comma-separated string or an array of glob patterns.
 
+### Content file options
+
+Using the `--fileopts` CLI flag or `setFileOpts()` API method, you can specify these options when reading content files:
+
+| Key | Default | Desc |
+| --- | --- | --- |
+| `matter` | `{delims: '+++', lang:'toml'}` | [Options](https://www.npmjs.com/package/gray-matter#read) for reading front matter |
+| `taxonomies` | `['tags']` | Array of taxonomies to include in index |
+| `indexDrafts` | `false` | Whether to include draft posts when building search index. Note that **future-dated posts will be indexed** (PRs welcome...) |
+| `params` | `[]` | Array of any other parameters to include in index, e.g. `date` |
+
+You can provide the path to a JSON file using CLI flag or API, or just pass an object directly when calling the API method.
+
 ## How to use hugo-lunr CLI
+
 The easiest way to use hugo-lunr is via npm scripts:
 ```
   "scripts": {
@@ -56,5 +72,6 @@ var h = new hugolunr();
 h.setInput('content/faq/**');
 h.setOutput('public/faq.json');
 h.setExcludes(['content/faq/images/**', 'content/faq/subdir/assets/**']);
+h.setFileOpts({ taxonomies: ['tags', 'categories'] });
 h.index();
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ $ npm install hugo-lunr
 ```
 
 ## Options
-By default hugo-lunr will read the `content` directory of you and output the lunr index to `public/lunr.json`. If you are using the command line implementation you can pass an input directory `-i` and and output path/file `-o`.
+By default hugo-lunr will read the `content` directory of you and output the lunr index to `public/lunr.json`. If you are using the command line implementation you can pass an input directory `-i` and an output path/file `-o`.
 
+To exclude folders within your input directory, you can pass comma-separated [glob patterns](https://www.npmjs.com/package/glob#glob-primer) with the `--excludes` parameter, e.g.
+
+```
+hugo-lunr -i \"content/subdir/**\" -o public/my-index.json --excludes \"content/images/**\"
+```
+
+Note that the API version of this flag (`setExcludes()`) can accept a comma-separated string or an array of glob patterns.
 
 ## How to use hugo-lunr CLI
 The easiest way to use hugo-lunr is via npm scripts:
@@ -48,7 +55,6 @@ var hugolunr = require('hugo-lunr');
 var h = new hugolunr();
 h.setInput('content/faq/**');
 h.setOutput('public/faq.json');
+h.setExcludes(['content/faq/images/**', 'content/faq/subdir/assets/**']);
 h.index();
 ```
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,14 @@ function HugoLunr(input, output){
 	this.output = 'public/lunr.json';
 	this.excludes = [];
 
+	// Default file reading options
+	this.fileOpts = {
+		matter: {delims: '+++', lang:'toml'},
+		taxonomies: ['tags'],
+		indexDrafts: false,
+		params: []
+	};
+
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
 	}
@@ -33,6 +41,10 @@ function HugoLunr(input, output){
 
 	if(process.argv.indexOf("--excludes") != -1){ //does excludes flag exist?
 	    this.setExcludes(process.argv[process.argv.indexOf("--excludes") + 1]); //grab the next item
+	}
+
+	if(process.argv.indexOf("--fileopts") != -1){ //does fileopts flag exist?
+	    this.setFileOpts(process.argv[process.argv.indexOf("--fileopts") + 1]); //grab the next item
 	}
 
 	this.baseDir = path.dirname(this.input);
@@ -51,6 +63,30 @@ HugoLunr.prototype.setExcludes = function(excludes) {
 	// Comma-separated array of glob paths from --excludes arg
 	// Or array if using API
 	this.excludes = typeof excludes === 'string' ? excludes.split(',') : excludes;
+}
+
+HugoLunr.prototype.setFileOpts = function(opts) {
+	// If string assume path to opts JSON file
+	// otherwise assume object was passed to API
+	var optsObj = opts;
+	if ('string' === typeof opts) {
+		try {
+			var filename = path.resolve(path.dirname(process.argv[1]), opts);
+			optsObj = JSON.parse(fs.readFileSync(filename, 'utf8'));
+		} catch (e)  {
+			optsObj = null;
+		}
+	}
+
+	if (!optsObj) {
+		return;
+	}
+
+	// Merge into this.fileOpts
+	var self = this;
+	Object.keys(optsObj).forEach(function(key) {
+		self.fileOpts[key] = optsObj[key];
+	});
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -88,34 +124,42 @@ HugoLunr.prototype.readDirectory = function(path){
 HugoLunr.prototype.readFile = function(filePath){
 	var self = this;
 	var ext = path.extname(filePath);
-	var meta = matter.read(filePath, {delims: '+++', lang:'toml'});
-	if (meta.data.draft === true){
+	var meta = matter.read(filePath, self.fileOpts.matter);
+	if (meta.data.draft === true && !self.fileOpts.indexDrafts){
 		return;
 	}
 
-	if (ext == '.md'){
-		var plainText = removeMd(meta.content);
-	} else {
-		var plainText = striptags(meta.content);
-	}
+	// Setup title and content
+	var item = {
+		title: meta.data.title || '',
+		content: ext == '.md' ? removeMd(meta.content) : striptags(meta.content)
+	};
 
-	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));
-	uri = uri.replace(self.baseDir +'/', '');
-
-	if (meta.data.slug !=  undefined){
-		uri = path.dirname(uri) + meta.data.slug;
-	}
-
+	// Setup URI
 	if (meta.data.url != undefined){
-		uri = meta.data.url
+		item.uri = meta.data.url;
+	} else {
+		var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));
+		uri = uri.replace(self.baseDir +'/', '');
+
+		if (meta.data.slug !=  undefined){
+			uri = path.dirname(uri) + meta.data.slug;
+		}
+
+		item.uri = uri;
 	}
 
-	var tags = [];
+	// Setup taxonomies
+	self.fileOpts.taxonomies.forEach(function(taxonomy) {
+		item[taxonomy] = meta.data[taxonomy] || [];
+	});
 
-	if (meta.data.tags != undefined){
-		tags = meta.data.tags;
+	// Setup additional specified params
+	if (self.fileOpts.params.length) {
+		self.fileOpts.params.forEach(function(param) {
+			item[param] = meta.data[param] || null;
+		});
 	}
 
-	var item = {'uri' : uri , 'title' : meta.data.title, 'content':plainText, 'tags':tags};
 	self.list.push(item);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,8 @@ function HugoLunr(input, output){
 		matter: {delims: '+++', lang:'toml'},
 		taxonomies: ['tags'],
 		indexDrafts: false,
-		params: []
+		params: [],
+		callback: null
 	};
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
@@ -159,6 +160,10 @@ HugoLunr.prototype.readFile = function(filePath){
 		self.fileOpts.params.forEach(function(param) {
 			item[param] = meta.data[param] || null;
 		});
+	}
+
+	if ('function' === typeof self.fileOpts.callback) {
+		item = self.fileOpts.callback(item);
 	}
 
 	self.list.push(item);

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ function HugoLunr(input, output){
 	//defaults
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
+	this.excludes = [];
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
@@ -28,6 +29,10 @@ function HugoLunr(input, output){
 
 	if(process.argv.indexOf("-i") != -1){ //does input flag exist?
 	    this.setInput(process.argv[process.argv.indexOf("-i") + 1]); //grab the next item
+	}
+
+	if(process.argv.indexOf("--excludes") != -1){ //does excludes flag exist?
+	    this.setExcludes(process.argv[process.argv.indexOf("--excludes") + 1]); //grab the next item
 	}
 
 	this.baseDir = path.dirname(this.input);
@@ -39,6 +44,12 @@ HugoLunr.prototype.setInput = function(input) {
 
 HugoLunr.prototype.setOutput = function(output) {
 	this.output = output;
+}
+
+HugoLunr.prototype.setExcludes = function(excludes) {
+	// Comma-separated array of glob paths from --excludes arg
+	// Or array if using API
+	this.excludes = typeof excludes === 'string' ? excludes.split(',') : excludes;
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -62,7 +73,7 @@ HugoLunr.prototype.index = function(input, output){
 
 HugoLunr.prototype.readDirectory = function(path){
 	var self = this;
-	var files = glob.sync(path);
+	var files = glob.sync(path, { ignore: this.excludes });
 	var len = files.length;
 	for (var i=0;i<len;i++){
 		var stats = fs.lstatSync(files[i]);
@@ -107,8 +118,3 @@ HugoLunr.prototype.readFile = function(filePath){
 	var item = {'uri' : uri , 'title' : meta.data.title, 'content':plainText, 'tags':tags};
 	self.list.push(item);
 }
-
-
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ function HugoLunr(input, output){
 
 HugoLunr.prototype.setInput = function(input) {
 	this.input = input;
+	this.baseDir = path.dirname(input);
 }
 
 HugoLunr.prototype.setOutput = function(output) {


### PR DESCRIPTION
`--excludes` and `HugoLunr.setExcludes()` take an array of glob patterns to ignore when calling `glob.sync()`

`--fileopts` and `HugoLunr.setFileOpts()` give you some options when reading content files for the index.