### PR TITLE
Basic set language support

### DIFF
--- a/bin/api.js
+++ b/bin/api.js
@@ -3,4 +3,5 @@ var hugolunr = require('../');
 var indexer = new hugolunr();
 indexer.setInput('content/faq/**');
 indexer.setOutput('public/faq.json');
+indexer.setLanguage('toml');
 indexer.index();

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,11 @@ HugoLunr.prototype.setOutput = function(output) {
 	this.output = output;
 }
 
-HugoLunr.prototype.setLanguage = function (language) {
+HugoLunr.prototype.setLanguage = function(language) {
+    this.language = language;
+}
+
+HugoLunr.prototype.setLanguageConfig = function (language) {
 	switch (true) {
 		case language.toLowerCase() === 'yaml':
 			this.languageConfig = {delims: '---', lang: 'yaml'};
@@ -69,7 +73,11 @@ HugoLunr.prototype.index = function(input, output, language){
 		self.output = output;
 	}
 
-	self.setLanguage(language || self.language)
+  if (language){
+    self.language = language;
+  }
+
+  self.setLanguageConfig(self.language)
 	self.list = [];
 	self.stream = fs.createWriteStream(self.output);
 	self.readDirectory(self.input);

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ exports.hugolunr = function(){
 module.exports = HugoLunr;
 
 
-function HugoLunr(input, output){
+function HugoLunr(input, output, language){
 	var self = this;
 	var stream;
 	this.list = [];
@@ -21,6 +21,7 @@ function HugoLunr(input, output){
 	//defaults
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
+  this.language = 'toml';
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
@@ -29,6 +30,10 @@ function HugoLunr(input, output){
 	if(process.argv.indexOf("-i") != -1){ //does input flag exist?
 	    this.setInput(process.argv[process.argv.indexOf("-i") + 1]); //grab the next item
 	}
+
+  if(process.argv.indexOf("-l") != -1) { //does language flag exist?
+    this.setLanguage(process.argv[process.argv.indexOf("-l") + 1]); //grab the next item
+  }
 
 	this.baseDir = path.dirname(this.input);
 }
@@ -41,7 +46,19 @@ HugoLunr.prototype.setOutput = function(output) {
 	this.output = output;
 }
 
-HugoLunr.prototype.index = function(input, output){
+HugoLunr.prototype.setLanguage = function (language) {
+	switch (true) {
+		case language.toLowerCase() === 'yaml':
+			this.languageConfig = {delims: '---', lang: 'yaml'};
+			break;
+		default:
+		case language.toLowerCase() === 'toml':
+			this.languageConfig = {delims: '+++', lang: 'toml'};
+			break;
+	}
+}
+
+HugoLunr.prototype.index = function(input, output, language){
 	var self = this;
 
 	if (input){
@@ -50,6 +67,10 @@ HugoLunr.prototype.index = function(input, output){
 
 	if (output){
 		self.output = output;
+	}
+
+	if (language) {
+			self.setLanguage(language)
 	}
 
 	self.list = [];
@@ -76,7 +97,7 @@ HugoLunr.prototype.readDirectory = function(path){
 HugoLunr.prototype.readFile = function(filePath){
 	var self = this;
 	var ext = path.extname(filePath);
-	var meta = matter.read(filePath);
+	var meta = matter.read(filePath, self.languageConfig);
 	if (meta.data.draft === true){
 		return;
 	}

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,10 +69,7 @@ HugoLunr.prototype.index = function(input, output, language){
 		self.output = output;
 	}
 
-	if (language) {
-			self.setLanguage(language)
-	}
-
+	self.setLanguage(language || self.language)
 	self.list = [];
 	self.stream = fs.createWriteStream(self.output);
 	self.readDirectory(self.input);

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ HugoLunr.prototype.readDirectory = function(path){
 HugoLunr.prototype.readFile = function(filePath){
 	var self = this;
 	var ext = path.extname(filePath);
-	var meta = matter.read(filePath, {delims: '+++', lang:'toml'});
+	var meta = matter.read(filePath);
 	if (meta.data.draft === true){
 		return;
 	}
@@ -107,8 +107,3 @@ HugoLunr.prototype.readFile = function(filePath){
 	var item = {'uri' : uri , 'title' : meta.data.title, 'content':plainText, 'tags':tags};
 	self.list.push(item);
 }
-
-
-
-
-


### PR DESCRIPTION
Allow the user to set matter language (`toml` or `yaml`).

### Usage:
##### CLI flag: 
```bash
hugo-lunr -l toml  # default
hugo-lunr -l yaml
```
##### API:
```js
var hugolunr = require('../');
var indexer = new hugolunr();
indexer.setInput('content/faq/**');
indexer.setOutput('public/faq.json');
indexer.setLanguage('toml');
indexer.index(); 
```
```js
# ... OR using index()
indexer.index('content/faq/**', 'public/faq.json', 'yaml'); 
```