### PR TITLE
Added option to ignore future posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ npm install hugo-lunr
 ```
 
 ## Options
-By default hugo-lunr will read the `content` directory of you and output the lunr index to `public/lunr.json`. If you are using the command line implementation you can pass an input directory `-i` and and output path/file `-o`.
+By default hugo-lunr will read the `content` directory of you and output the lunr index to `public/lunr.json`. If you are using the command line implementation you can pass an input directory `-i` and and output path/file `-o`. Optionally, you can exclude future ports not marked as draft with the option `-f false`.
 
 
 ## How to use hugo-lunr CLI
@@ -48,6 +48,7 @@ var hugolunr = require('hugo-lunr');
 var h = new hugolunr();
 h.setInput('content/faq/**');
 h.setOutput('public/faq.json');
+h.setIncludeFuture(false); // Optional. Default true.
 h.index();
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,8 @@ HugoLunr.prototype.readFile = function(filePath){
 	if (ext == '.md'){
 		var plainText = removeMd(meta.content);
 	} else {
-		var plainText = striptags(meta.content);
+		// var plainText = striptags(meta.content);
+		return
 	}
 
 	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,6 @@ HugoLunr.prototype.readFile = function(filePath){
 	if (!self.includeFuture && meta.data.date !== undefined) {
 		var contentDate = new Date(meta.data.date)
 		var currentDate = new Date();
-		console.log(contentDate, '>', currentDate, '?', contentDate > currentDate, 'for', meta.data.title)
 		if (contentDate > currentDate) {
 			return;
 		}
@@ -103,8 +102,7 @@ HugoLunr.prototype.readFile = function(filePath){
 	if (ext == '.md'){
 		var plainText = removeMd(meta.content);
 	} else {
-		// var plainText = striptags(meta.content);
-		return
+		var plainText = striptags(meta.content);
 	}
 
 	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,13 +22,19 @@ function HugoLunr(input, output){
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
 
- 	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
+ 	if (process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
 	}
 
-	if(process.argv.indexOf("-i") != -1){ //does input flag exist?
+	if (process.argv.indexOf("-i") != -1){ //does input flag exist?
 	    this.setInput(process.argv[process.argv.indexOf("-i") + 1]); //grab the next item
 	}
+
+	var includeFuture = true;
+	if (process.argv.indexOf("-f") != -1){ //does input flag exist?
+		includeFuture = process.argv[process.argv.indexOf("-i") + 1] == "true";
+	}
+	this.setIncludeFuture(includeFuture);
 
 	this.baseDir = path.dirname(this.input);
 }
@@ -39,6 +45,10 @@ HugoLunr.prototype.setInput = function(input) {
 
 HugoLunr.prototype.setOutput = function(output) {
 	this.output = output;
+}
+
+HugoLunr.prototype.setIncludeFuture = function(includeFuture) {
+	this.includeFuture = includeFuture;
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -79,6 +89,15 @@ HugoLunr.prototype.readFile = function(filePath){
 	var meta = matter.read(filePath, {delims: '+++', lang:'toml'});
 	if (meta.data.draft === true){
 		return;
+	}
+
+	if (!self.includeFuture && meta.data.date !== undefined) {
+		var contentDate = new Date(meta.data.date)
+		var currentDate = new Date();
+		console.log(contentDate, '>', currentDate, '?', contentDate > currentDate, 'for', meta.data.title)
+		if (contentDate > currentDate) {
+			return;
+		}
 	}
 
 	if (ext == '.md'){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-lunr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "create lunr index file for hugo static site search",
   "repository": {
     "type": "git",
@@ -12,9 +12,9 @@
     "hugo-lunr": "bin/index.js"
   },
   "scripts": {
-    "test": "bin/index.js ",
-    "test-args": "bin/index.js -i \"content/**\" -o public/output.json",
-    "test-api": "bin/api.js"
+    "test": "node bin/index.js",
+    "test-args": "node bin/index.js -i \"content/**\" -o public/output.json",
+    "test-api": "node bin/api.js"
   },
   "author": "Derrick Grigg <derrick@dgrigg.com> (http://dgrigg.com)",
   "license": "ISC",
@@ -26,5 +26,3 @@
     "toml": "^2.3.0"
   }
 }
-
-


### PR DESCRIPTION
Besides ignoring drafted posts, it's interesting to have the ability to ignore posts with future dates, which Hugo does not publish by default (only with the -F argument).

It's necessary for blogs that work with scheduled content, otherwise content not yet published will be findable in searches on the index.