### PR TITLE
Make index generation more flexible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ function HugoLunr(input, output){
 	//defaults
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
+    this.verbose = false;
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
@@ -28,6 +29,10 @@ function HugoLunr(input, output){
 
 	if(process.argv.indexOf("-i") != -1){ //does input flag exist?
 	    this.setInput(process.argv[process.argv.indexOf("-i") + 1]); //grab the next item
+	}
+
+	if(process.argv.indexOf("-v") != -1){ //does input flag exist?
+	    this.setVerbose(!this.verbose); //Toggle the verbose flag
 	}
 
 	this.baseDir = path.dirname(this.input);
@@ -39,6 +44,10 @@ HugoLunr.prototype.setInput = function(input) {
 
 HugoLunr.prototype.setOutput = function(output) {
 	this.output = output;
+}
+
+HugoLunr.prototype.setVerbose = function(input) {
+	this.verbose = input;
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -83,9 +92,13 @@ HugoLunr.prototype.readFile = function(filePath){
 
 	if (ext == '.md'){
 		var plainText = removeMd(meta.content);
-	} else {
+	} else if (ext == '.html') {
 		var plainText = striptags(meta.content);
-	}
+	} else {
+        if (this.verbose) {
+            console.log("Sikpping " + filePath)
+        }
+    }
 
 	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));
 	uri = uri.replace(self.baseDir +'/', '');

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,8 +22,9 @@ function HugoLunr(input, output){
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
     this.verbose = false;
-    this.delims = '+++'
-    this.language = 'toml'
+    this.delims = '+++';
+    this.language = 'toml';
+    this.stripIndex = false;
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
@@ -43,6 +44,10 @@ function HugoLunr(input, output){
 
 	if(process.argv.indexOf("-v") != -1){ //does input flag exist?
 	    this.setVerbose(!this.verbose); //Toggle the verbose flag
+	}
+
+	if(process.argv.indexOf("-s") != -1){ //does input flag exist?
+	    this.setStripIndex(!this.stripIndex); //Toggle the stripIndex flag
 	}
 
 	this.baseDir = path.dirname(this.input);
@@ -66,6 +71,10 @@ HugoLunr.prototype.setDelims = function(input) {
 
 HugoLunr.prototype.setLanguage = function(input) {
 	this.language = input;
+}
+
+HugoLunr.prototype.setStripIndex = function(input) {
+	this.stripIndex = input;
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -122,8 +131,12 @@ HugoLunr.prototype.readFile = function(filePath){
         return
     }
 
-	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));
+    var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));
 	uri = uri.replace(self.baseDir +'/', '');
+
+    if (this.stripIndex && uri.endsWith('index')) {
+        uri = uri.substring(0,filePath.lastIndexOf('index'));
+    }
 
 	if (meta.data.slug !=  undefined){
 		uri = path.dirname(uri) + meta.data.slug;

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,8 @@ function HugoLunr(input, output){
 	this.input = 'content/**';
 	this.output = 'public/lunr.json';
     this.verbose = false;
+    this.delims = '+++'
+    this.language = 'toml'
 
  	if(process.argv.indexOf("-o") != -1){ //does output flag exist?
 		this.setOutput(process.argv[process.argv.indexOf("-o") + 1]); //grab the next item
@@ -29,6 +31,14 @@ function HugoLunr(input, output){
 
 	if(process.argv.indexOf("-i") != -1){ //does input flag exist?
 	    this.setInput(process.argv[process.argv.indexOf("-i") + 1]); //grab the next item
+	}
+
+	if(process.argv.indexOf("-d") != -1){ //does input flag exist?
+	    this.setDelims(process.argv[process.argv.indexOf("-d") + 1]); //grab the next item
+	}
+
+	if(process.argv.indexOf("-l") != -1){ //does input flag exist?
+	    this.setLanguage(process.argv[process.argv.indexOf("-l") + 1]); //grab the next item
 	}
 
 	if(process.argv.indexOf("-v") != -1){ //does input flag exist?
@@ -48,6 +58,14 @@ HugoLunr.prototype.setOutput = function(output) {
 
 HugoLunr.prototype.setVerbose = function(input) {
 	this.verbose = input;
+}
+
+HugoLunr.prototype.setDelims = function(input) {
+	this.delims = input;
+}
+
+HugoLunr.prototype.setLanguage = function(input) {
+	this.language = input;
 }
 
 HugoLunr.prototype.index = function(input, output){
@@ -85,8 +103,11 @@ HugoLunr.prototype.readDirectory = function(path){
 HugoLunr.prototype.readFile = function(filePath){
 	var self = this;
 	var ext = path.extname(filePath);
-	var meta = matter.read(filePath, {delims: '+++', lang:'toml'});
-	if (meta.data.draft === true){
+	var meta = matter.read(filePath, {
+        delims: this.delims,
+        lang: this.language
+    });
+    if (meta.data.draft === true){
 		return;
 	}
 
@@ -98,6 +119,7 @@ HugoLunr.prototype.readFile = function(filePath){
         if (this.verbose) {
             console.log("Sikpping " + filePath)
         }
+        return
     }
 
 	var uri = '/' + filePath.substring(0,filePath.lastIndexOf('.'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,8 @@ HugoLunr.prototype.readFile = function(filePath){
 		uri = meta.data.url
 	}
 
+    console.log(uri)
+    
 	var tags = [];
 
 	if (meta.data.tags != undefined){

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ HugoLunr.prototype.readFile = function(filePath){
 	uri = uri.replace(self.baseDir +'/', '');
 
     if (this.stripIndex && uri.endsWith('index')) {
-        uri = uri.substring(0,filePath.lastIndexOf('index'));
+        uri = uri.substring(0,uri.lastIndexOf('index'));
     }
 
 	if (meta.data.slug !=  undefined){
@@ -146,8 +146,6 @@ HugoLunr.prototype.readFile = function(filePath){
 		uri = meta.data.url
 	}
 
-    console.log(uri)
-    
 	var tags = [];
 
 	if (meta.data.tags != undefined){


### PR DESCRIPTION
This PR updates the indexing to be more flexible in some ways and more restrictive in one significant way.

More flexible:
* Added a `-v` (verbose) flag to control runtime logging
* Added a `-l` (languages) parameter to allow for changing what format (yaml, toml, etc) the front-matter is in
* Added a `-d` (delimiter) parameter to allow for changing what sets off the  front-matter
* Added a `-s` (stripIndex) flag to handle folders with an index.md file. Without this flag the URI used in the index would be <path>/index, which doesn't work.

Less flexible:
The current system uses `grey-matter` to handle markdown files and assumes all other files are HTML. On my site this caused the index to include Javascript and image files. This PR changes the file walker to only process `.md` and `.html` files. Optionally (based on the verbose flag above), skipped files are noted on the console.